### PR TITLE
xlab(NULL) is better than xlab('')

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -95,8 +95,8 @@ p1 = ggplot_calendar_heatmap(
 
 # adding some formatting
 p1 + 
-   xlab('') + 
-   ylab('') + 
+   xlab(NULL) + 
+   ylab(NULL) + 
    scale_fill_continuous(low = 'green', high = 'red') + 
    facet_wrap(~Year, ncol = 1)
 
@@ -113,8 +113,8 @@ p2 = ggplot_calendar_heatmap(
 
 # adding some formatting
 p2 + 
-   xlab('') + 
-   ylab('') + 
+   xlab(NULL) + 
+   ylab(NULL) + 
    facet_wrap(~Year, ncol = 1)
 
 
@@ -140,8 +140,8 @@ p1 = ggplot_horizon(dfData, 'x', 'y')
 print("If you're seeing any vertical white stripes, it's a display thing.")
 # adding some formatting
 p1 + 
-   xlab('') + 
-   ylab('') + 
+   xlab(NULL) + 
+   ylab(NULL) + 
    scale_fill_continuous(low = 'green', high = 'red') + 
    coord_fixed( 0.5 * diff(range(dfData$x)) / diff(range(dfData$y)))
 ```
@@ -176,8 +176,8 @@ p1 = ggplot(dfData, aes(x = Time, y = Signal, group = VariableLabel, fill = Vari
 
 # adding some formatting
 p1 + 
-   xlab('') + 
-   ylab('') + 
+   xlab(NULL) + 
+   ylab(NULL) + 
    coord_fixed( 0.2 * diff(range(dfData$Time)) / diff(range(dfData$Signal)))
 
 ```
@@ -203,8 +203,8 @@ p1 = ggplot_waterfall(
 
 # adding some formatting
 p1 + 
-   xlab('') + 
-   ylab('')
+   xlab(NULL) + 
+   ylab(NULL)
 ```
 
 
@@ -225,7 +225,7 @@ p1 = ggplot(dfData, aes(x =x, y = y) )+
 
 # adding some formatting   
 p1 +
-   xlab('') + 
-   ylab('') + 
+   xlab(NULL) + 
+   ylab(NULL) + 
    coord_fixed(ylim = c(0,1 + max(dfData$y)))
 ```


### PR DESCRIPTION
I personally think you want the graph occupies more area, so `xlab(NULL)` and `ylab(NULL)` is more suitable than `xlab('')`.

I also notice that in the documentations there're still codes use the `xlab('')`. If you allowed, I would be happy to change those code and submit a PR again. :laughing: 